### PR TITLE
remove flicker when pushing view controller without animation

### DIFF
--- a/FRLayeredNavigationController/FRLayeredNavigationController.m
+++ b/FRLayeredNavigationController/FRLayeredNavigationController.m
@@ -612,21 +612,31 @@ configuration:(void (^)(FRLayeredNavigationItem *item))configuration
     [self addChildViewController:newVC];
     [self.view addSubview:newVC.view];
 
-    [UIView animateWithDuration:animated ? 0.5 : 0
-                          delay:0
-                        options: UIViewAnimationCurveEaseOut
-                     animations:^{
-                         CGFloat saved = [self savePlaceWanted:CGRectGetMinX(onscreenFrame)+width-overallWidth];
-                         newVC.view.frame = CGRectMake(CGRectGetMinX(onscreenFrame) - saved,
-                                                       CGRectGetMinY(onscreenFrame),
-                                                       CGRectGetWidth(onscreenFrame),
-                                                       CGRectGetHeight(onscreenFrame));
-                         newVC.layeredNavigationItem.currentViewPosition = newVC.view.frame.origin;
+    if(animated) {
+        [UIView animateWithDuration:animated ? 0.5 : 0
+                              delay:0
+                            options: UIViewAnimationCurveEaseOut
+                         animations:^{
+                             CGFloat saved = [self savePlaceWanted:CGRectGetMinX(onscreenFrame)+width-overallWidth];
+                             newVC.view.frame = CGRectMake(CGRectGetMinX(onscreenFrame) - saved,
+                                                           CGRectGetMinY(onscreenFrame),
+                                                           CGRectGetWidth(onscreenFrame),
+                                                           CGRectGetHeight(onscreenFrame));
+                             newVC.layeredNavigationItem.currentViewPosition = newVC.view.frame.origin;
 
-                     }
-                     completion:^(BOOL finished) {
-                         [newVC didMoveToParentViewController:self];
-                     }];
+                         }
+                         completion:^(BOOL finished) {
+                             [newVC didMoveToParentViewController:self];
+                         }];
+    } else {
+        CGFloat saved = [self savePlaceWanted:CGRectGetMinX(onscreenFrame)+width-overallWidth];
+        newVC.view.frame = CGRectMake(CGRectGetMinX(onscreenFrame) - saved,
+                                      CGRectGetMinY(onscreenFrame),
+                                      CGRectGetWidth(onscreenFrame),
+                                      CGRectGetHeight(onscreenFrame));
+        newVC.layeredNavigationItem.currentViewPosition = newVC.view.frame.origin;
+        [newVC didMoveToParentViewController:self];
+    }
 }
 
 - (void)pushViewController:(UIViewController *)contentViewController


### PR DESCRIPTION
There is a slight flicker if you push a new view controller without animation. This change adds a conditional block instead of setting the animation duration to 0s.
