### PR TITLE
[FEATURE] Added 'autosizeContent' to FRLayeredNavigationItem

### DIFF
--- a/FRLayeredNavigationController/FRLayerController.m
+++ b/FRLayeredNavigationController/FRLayerController.m
@@ -116,7 +116,9 @@
     if (self.layeredNavigationItem.hasBorder) {
         self.borderView.frame = borderFrame;
     }
-    self.contentView.frame = contentFrame;
+    if (self.layeredNavigationItem.autosizeContent) {
+        self.contentView.frame = contentFrame;
+    }
 }
 
 

--- a/FRLayeredNavigationController/FRLayeredNavigationItem.h
+++ b/FRLayeredNavigationController/FRLayeredNavigationItem.h
@@ -47,6 +47,7 @@
     BOOL _hasChrome;
     BOOL _hasBorder;
     BOOL _displayShadow;
+    BOOL _autosizeContent;
     FRLayerController __weak * _layerController;
 }
 
@@ -94,6 +95,11 @@
  * If the view should display a shadow
  */
 @property (nonatomic, readwrite) BOOL displayShadow;
+
+/**
+ * If the view should automatically size its content to the layer size
+ */
+@property (nonatomic, readwrite) BOOL autosizeContent;
 
 /**
  * A custom bar button item displayed on the left of the navigation bar.

--- a/FRLayeredNavigationController/FRLayeredNavigationItem.m
+++ b/FRLayeredNavigationController/FRLayeredNavigationItem.m
@@ -49,6 +49,7 @@
         self->_hasChrome = YES;
         self->_displayShadow = YES;
         self->_hasBorder = YES;
+        self->_autosizeContent = YES;
     }
 
     return self;
@@ -84,6 +85,7 @@
 @synthesize hasChrome = _hasChrome;
 @synthesize hasBorder = _hasBorder;
 @synthesize displayShadow = _displayShadow;
+@synthesize autosizeContent = _autosizeContent;
 @synthesize layerController = _layerController;
 
 @end


### PR DESCRIPTION
This pull request adds `FRLayeredNavigationItem.autosizeContent`. This allows you to size layers differently from their content controller view, giving you the ability to do things like add decorations or other visual niceties which may not be available in your controller (or take too much custom work), such as adding images on the right border to a layer containing a `UITableViewController`.

The default value is consistent with the current behavior.
